### PR TITLE
Fix RuntimeError in animate.py: Ensure  parameters are sequences

### DIFF
--- a/animate.py
+++ b/animate.py
@@ -145,10 +145,10 @@ def animate(frame, fargs):
     rear_right_wheel.set_data(*rr_plot)
     front_left_wheel.set_data(*fl_plot)
     rear_left_wheel.set_data(*rl_plot)
-    rear_axle.set_data(car.x, car.y)
+    rear_axle.set_data([car.x], [car.y])
 
     # Show car's target
-    target.set_data(path.px[car.target_id], path.py[car.target_id])
+    target.set_data([path.px[car.target_id]], [path.py[car.target_id]])
 
     # Annotate car's coordinate above car
     annotation.set_text(f'{car.x:.1f}, {car.y:.1f}')


### PR DESCRIPTION
This pull request addresses a `RuntimeError` that occurs when running `animate.py` in the `KinematicBicycleModel` project. The error message indicated that the `set_data` function parameters must be sequences, but in the current implementation, they were provided as single float values.

To resolve this issue, the parameters have been explicitly cast into lists to ensure they are recognized as sequences.

#### Changes made:
- **Line 149:**
  - **Original:**
    ```python
    rear_axle.set_data(car.x, car.y)
    ```
  - **Updated:**
    ```python
    rear_axle.set_data([car.x], [car.y])
    ```

- **Line 152:**
  - **Original:**
    ```python
    target.set_data(path.px[car.target_id], path.py[car.target_id])
    ```
  - **Updated:**
    ```python
    target.set_data([path.px[car.target_id]], [path.py[car.target_id]])
    ```

#### Environment Details:
- **Python Version:** 3.10.14
- **Relevant Packages:**
  - matplotlib 3.9.2
  - numpy 1.23.5
  - scipy 1.8.0

These changes ensure that the `animate.py` script runs without errors and that the `set_data` function operates correctly by using sequences as required by the `matplotlib` library.